### PR TITLE
Fixed issue with the display of the + sign

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/statistics/statistics.html
+++ b/ui.apps/src/main/content/jcr_root/apps/asset-share-commons/components/search/statistics/statistics.html
@@ -34,7 +34,7 @@
 
 		<div class="statistic">
 			<div class="value">
-				${component.total}${component.more ? '+' : '' @ i18n}
+				${component.total}${component.hasMore ? '+' : '' @ i18n}
 			</div>
 			<div class="label">
 				${properties['totalLabel']}


### PR DESCRIPTION
Hi,

When trying to test the display of the + sign next to the TOTAL number in the Statistics component, it didn't work.

I updated statistics.html and replaced **component.more** by **component.hasMore** to fix the issue.